### PR TITLE
Multiple versions

### DIFF
--- a/source/notebooks/Sample.ipynb
+++ b/source/notebooks/Sample.ipynb
@@ -8,7 +8,7 @@
    },
    "outputs": [],
    "source": [
-    "from sqlalchemy import create_engine\n",
+    "from sqlalchemy import create_engine, desc\n",
     "from idetect.model import db_url, Base, Article, Session, Status\n",
     "\n",
     "# connect to the DB specified in the docker.env file\n",
@@ -36,8 +36,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# what articles already exist?\n",
-    "[(a.url, a.status) for a in session.query(Article).order_by(Article.url).all()]"
+    "# add an article to the database\n",
+    "article1 = Article(url=\"http://www.internal-displacement.org/\", url_id=1, status=Status.NEW)\n",
+    "session.add(article1)\n",
+    "session.commit()\n",
+    "\n",
+    "article2 = Article(url=\"http://datafordemocracy.org/\", url_id=2, status=Status.NEW)\n",
+    "session.add(article2)\n",
+    "session.commit()"
    ]
   },
   {
@@ -46,10 +52,58 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# add an article to the database\n",
-    "article = Article(url=\"http://www.internal-displacement.org/\", status=Status.NEW)\n",
-    "session.add(article)\n",
-    "session.commit()"
+    "# what is the current state of the Article with url_id 1?\n",
+    "Article.get_latest_version(session, url_id=1).status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# what is the current state of the second article we added above?\n",
+    "article2.get_updated_version().status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# what is the latest version of each article that exists?\n",
+    "[(str(a), a.status)\n",
+    " for a in Article.select_latest_version(session)\\\n",
+    " .order_by(Article.url)\\\n",
+    " .all()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# all versions of all articles\n",
+    "[(a.id, a.url_id, a.status, str(a.updated)) \n",
+    " for a in session.query(Article)\\\n",
+    " .order_by(desc(Article.updated))\\\n",
+    " .all()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# what articles are currently in the processed state\n",
+    "[(str(a), a.status, str(a.updated))\n",
+    " for a in Article.select_latest_version(session)\\\n",
+    " .filter(Article.status == Status.PROCESSED)\\\n",
+    " .order_by(Article.url)\\\n",
+    " .all()]"
    ]
   },
   {
@@ -79,14 +133,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# run that worker a single time\n",
     "worker.work()\n",
     "\n",
-    "# note that if the flask/api container is running, there are some workers in there that will compete with this,\n",
-    "# so use `docker compose up notebooks` instead of just `docker compose up`"
+    "# note that if the workers container is running, there are some workers in there that will compete with this,\n",
+    "# so use `docker compose up notebooks localdb` instead of just `docker compose up`"
    ]
   },
   {
@@ -96,9 +152,7 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": [
-    ""
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -110,7 +164,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -121,5 +175,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/source/python/idetect/model.py
+++ b/source/python/idetect/model.py
@@ -49,6 +49,7 @@ article_report = Table(
     Column('report', ForeignKey('report.id', ondelete="CASCADE"), primary_key=True)
 )
 
+
 class Article(Base):
     __tablename__ = 'article'
 
@@ -137,6 +138,23 @@ class Article(Base):
         """
         Returns a SELECT query that will only match the most recent versions of the articles it matches.
         You can further filter/order/limit the query.
+        
+        The query returned is of the form:
+        
+        SELECT a.*
+        FROM (SELECT article.*,
+                     row_number() OVER (PARTITION BY article.url_id ORDER BY article.updated DESC) AS row_number 
+              FROM article) AS a 
+        WHERE a.row_number = 1
+        
+        You can add further clauses by applying filters, orders, and limits like
+            .filter(Article.status == Status.NEW)
+            .order_by(Article.updated)
+            .first()
+        adds
+            AND a.status = 'NEW'
+            ORDER BY a.updated
+            LIMIT 1
         """
         sub = session.query(
             Article,

--- a/source/python/idetect/tests/test_model.py
+++ b/source/python/idetect/tests/test_model.py
@@ -13,7 +13,7 @@ class TestModel(TestCase):
         db_host = os.environ.get('DB_HOST')
         db_url = 'postgresql://{user}:{passwd}@{db_host}/{db}'.format(
             user='tester', passwd='tester', db_host=db_host, db='idetect_test')
-        engine = create_engine(db_url)
+        engine = create_engine(db_url, echo=True)
         Session.configure(bind=engine)
         Base.metadata.drop_all(engine)
         Base.metadata.create_all(engine)

--- a/source/python/idetect/tests/test_worker.py
+++ b/source/python/idetect/tests/test_worker.py
@@ -44,7 +44,7 @@ class TestWorker(TestCase):
     def test_work_one(self):
         worker = Worker(Status.NEW, Status.FETCHING, Status.FETCHED, Status.FETCHING_FAILED,
                         TestWorker.nap_fn, self.engine)
-        article = Article(url='http://example.com', status=Status.NEW)
+        article = Article(url='http://example.com', url_id=1, status=Status.NEW)
         self.session.add(article)
         self.session.commit()
         self.assertTrue(worker.work(), "Worker didn't find work")
@@ -61,7 +61,7 @@ class TestWorker(TestCase):
     def test_work_failure(self):
         worker = Worker(Status.NEW, Status.FETCHING, Status.FETCHED, Status.FETCHING_FAILED,
                         TestWorker.err_fn, self.engine)
-        article = Article(url='http://example.com', status=Status.NEW)
+        article = Article(url='http://example.com', url_id=1, status=Status.NEW)
         self.session.add(article)
         self.session.commit()
         self.assertTrue(worker.work(), "Worker didn't find work")
@@ -76,7 +76,7 @@ class TestWorker(TestCase):
                          TestWorker.nap_fn, self.engine)
         worker2 = Worker(Status.FETCHED, Status.PROCESSING, Status.PROCESSED, Status.PROCESSING_FAILED,
                          TestWorker.nap_fn, self.engine)
-        article = Article(url='http://example.com', status=Status.NEW)
+        article = Article(url='http://example.com', url_id=1, status=Status.NEW)
         self.session.add(article)
         self.session.commit()
         self.assertFalse(worker2.work(), "Worker2 found work")
@@ -94,7 +94,7 @@ class TestWorker(TestCase):
                         TestWorker.nap_fn, self.engine)
         n = 3
         for i in range(n):
-            article = Article(url='http://example.com', status=Status.NEW)
+            article = Article(url='http://example.com', url_id=i, status=Status.NEW)
             self.session.add(article)
             self.session.commit()
         self.assertEqual(worker.work_all(), 3)
@@ -105,7 +105,7 @@ class TestWorker(TestCase):
     def test_work_parallel(self):
         n = 100
         for i in range(n):
-            article = Article(url='http://example.com', status=Status.NEW)
+            article = Article(url='http://example.com', url_id=i, status=Status.NEW)
             self.session.add(article)
             self.session.commit()
         self.processes += Worker.start_processes(4, Status.NEW, Status.FETCHING, Status.FETCHED, Status.FETCHING_FAILED,

--- a/source/python/idetect/worker.py
+++ b/source/python/idetect/worker.py
@@ -5,10 +5,11 @@ import signal
 import time
 from multiprocessing import Process
 
-from idetect.model import Article, UnexpectedArticleStatusException, Session
+from idetect.model import Article, Session, NotLatestException
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
 
 class Worker:
     def __init__(self, status, working_status, success_status, failure_status, function, engine):
@@ -45,29 +46,35 @@ class Worker:
             article = None
             while not claimed_one:
                 try:
-                    article = self.session.query(Article).filter(Article.status == self.status) \
-                        .order_by(Article.updated).first()  # choose the least-recently-updated article with this status
+                    # Only consider the most recent article for each url_id
+                    # ... that has the right status
+                    # ... sort by updated date
+                    # ... pick the first (oldest)
+                    article = Article.select_latest_version(self.session) \
+                        .filter(Article.status == self.status) \
+                        .order_by(Article.updated) \
+                        .first()
                     if article is None:
                         return False  # no work to be done
-                    article.update_status(self.working_status)
+                    article.create_new_version(self.working_status)
                     self.session.commit()
                     logger.info("Worker {} claimed Article {} in status {}".format(
                         os.getpid(), article.id, self.status))
                     claimed_one = True
-                except UnexpectedArticleStatusException:
+                except NotLatestException:
                     pass  # another worker claimed this article before we could, try again
             try:
                 # actually run the work function on this article
                 self.function(article)
                 logger.info("Worker {} processed Article {} {} -> {}".format(
                     os.getpid(), article.id, self.status, self.success_status))
-                article.update_status(self.success_status)
+                article.create_new_version(self.success_status)
                 self.session.commit()
             except Exception as e:
                 logger.warn("Worker {} failed to process Article {} {} -> {}".format(
                     os.getpid(), article.id, self.status, self.failure_status),
-                            exc_info=e)
-                article.update_status(self.failure_status)
+                    exc_info=e)
+                article.create_new_version(self.failure_status)
                 self.session.commit()
             return True
         finally:
@@ -84,7 +91,7 @@ class Worker:
     def work_indefinitely(self, max_sleep=60):
         """While there is work to do, do it. If there's no work to do, take increasingly long naps until there is."""
         logger.info("Worker {} working indefinitely".format(os.getpid()))
-        time.sleep(random.randrange(max_sleep)) # stagger start times
+        time.sleep(random.randrange(max_sleep))  # stagger start times
         sleep = 1
         while not self.terminated:
             if self.work_all() > 0:


### PR DESCRIPTION
This adds support for multiple versions of Articles (differentiated by the `updated` column).

An instance of an Article can `get_updated_version` (which returns the latest version of that Article), and `create_new_version` (which creates a new version with a specified `status`, changing the Article in place... that is no need to say `article2 = article1.create_new_version(status)`).

The Article class has class methods to get the latest Article for a given url/url_id, and to create a SELECT statement that uses a window function to only select the most recent version of any articles that match subsequent filters.