### PR TITLE
Local data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ logs/workers/*.log
 logs
 
 **/.DS_Store
+pgdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: localdb
     ports:
       - 5433:5432
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
   api:
     build:
       context: .
@@ -12,7 +14,7 @@ services:
       args:
         - UID=${UID}
     image: idetect
-    command: python3 /home/idetect/python/run_api.py
+    command: sh -c "sleep 5; python3 /home/idetect/python/run_api.py"
     volumes:
       - ./source:/home/idetect
     ports:

--- a/pgdata/Readme.md
+++ b/pgdata/Readme.md
@@ -1,0 +1,3 @@
+# Data Directory
+
+This directory will be mounted as a volume in the localdb container.


### PR DESCRIPTION
Instead of having the postgres data live on an ephemeral volume that goes away when you run `docker-compose down`, have it live in the `pgdata` subdirectory on the host machine.